### PR TITLE
Make property voice control friendly

### DIFF
--- a/zb-classifier.js
+++ b/zb-classifier.js
@@ -795,7 +795,7 @@ class ZigbeeClassifier {
       'instantaneousPower',           // name
       {// property description
         '@type': 'InstantaneousPowerProperty',
-        label: 'Power',
+        label: 'Energy',
         type: 'number',
         unit: 'watt',
         readOnly: true,
@@ -897,7 +897,7 @@ class ZigbeeClassifier {
       'instantaneousPower',           // name
       {// property description
         '@type': 'InstantaneousPowerProperty',
-        label: 'Power',
+        label: 'Energy',
         type: 'number',
         unit: 'watt',
         readOnly: true,

--- a/zb-classifier.js
+++ b/zb-classifier.js
@@ -454,7 +454,7 @@ class ZigbeeClassifier {
       'on',                           // name
       {// property description
         '@type': 'OnOffProperty',
-        label: 'On/Off',
+        label: 'Power',
         type: 'boolean',
       },
       endpoint.profileId,             // profileId
@@ -473,7 +473,7 @@ class ZigbeeClassifier {
       'on',                           // name
       {// property description
         '@type': 'BooleanProperty',
-        label: 'On/Off',
+        label: 'Power',
         type: 'boolean',
         readOnly: true,
       },

--- a/zb-classifier.js
+++ b/zb-classifier.js
@@ -454,7 +454,7 @@ class ZigbeeClassifier {
       'on',                           // name
       {// property description
         '@type': 'OnOffProperty',
-        label: 'Power',
+        label: 'Switch',
         type: 'boolean',
       },
       endpoint.profileId,             // profileId
@@ -473,7 +473,7 @@ class ZigbeeClassifier {
       'on',                           // name
       {// property description
         '@type': 'BooleanProperty',
-        label: 'Power',
+        label: 'Switch',
         type: 'boolean',
         readOnly: true,
       },
@@ -795,7 +795,7 @@ class ZigbeeClassifier {
       'instantaneousPower',           // name
       {// property description
         '@type': 'InstantaneousPowerProperty',
-        label: 'Energy',
+        label: 'Power usage',
         type: 'number',
         unit: 'watt',
         readOnly: true,
@@ -897,7 +897,7 @@ class ZigbeeClassifier {
       'instantaneousPower',           // name
       {// property description
         '@type': 'InstantaneousPowerProperty',
-        label: 'Energy',
+        label: 'Power usage',
         type: 'number',
         unit: 'watt',
         readOnly: true,


### PR DESCRIPTION
This improves voice control ability.
- A user that wants to toggle the "On/Off" property by voice might have to say "On slash off".
- Even if the above issues is worked around technically, it's still sub-optimal grammatically. E.g. a user that wants to target a property verbally might have to say "Turn on the on/off property of the device" or "Enable on off of the bedroom light".

Using "power" solves both issues.

Fixes #192