### PR TITLE
workaround to enable Scenes on TRADFRI 5 button remote

### DIFF
--- a/zb-classifier.js
+++ b/zb-classifier.js
@@ -2039,13 +2039,21 @@ class ZigbeeClassifier {
       this.addButtonLevelProperty(node, genLevelCtrlOutputEndpoint);
 
     if (node.modelId === 'TRADFRI remote control') {
-      const genScenesOutputEndpoint =
-        node.findZhaEndpointWithOutputClusterIdHex(CLUSTER_ID.GENSCENES_HEX) ||
-        '1';    // fake in endpoint 1 as version E1810 is missing the GENSCENES output cluster
-
-      const sceneProperty =
-        this.addButtonSceneProperty(node, genScenesOutputEndpoint);
-      sceneProperty.buttonIndex = 4;
+      let genScenesOutputEndpoint =
+        node.findZhaEndpointWithOutputClusterIdHex(CLUSTER_ID.GENSCENES_HEX);
+      if (!genScenesOutputEndpoint &&
+          genOnOffOutputEndpoint &&
+          node.activeEndpoints[genOnOffOutputEndpoint] &&
+          node.activeEndpoints[genOnOffOutputEndpoint].deviceId === '0820') {
+        // Workaround: version E1810 (deviceId 0820) is missing the GENSCENES
+        // output cluster but still receives updates on that cluster
+        genScenesOutputEndpoint = genOnOffOutputEndpoint;
+      }
+      if (genScenesOutputEndpoint) {
+        const sceneProperty =
+          this.addButtonSceneProperty(node, genScenesOutputEndpoint);
+        sceneProperty.buttonIndex = 4;
+      }
 
       // This is the IKEA remote with a center button and 4 other
       // buttons around the edge. The center button sends a toggle

--- a/zb-classifier.js
+++ b/zb-classifier.js
@@ -2040,12 +2040,12 @@ class ZigbeeClassifier {
 
     if (node.modelId === 'TRADFRI remote control') {
       const genScenesOutputEndpoint =
-        node.findZhaEndpointWithOutputClusterIdHex(CLUSTER_ID.GENSCENES_HEX);
-      if (genScenesOutputEndpoint) {
-        const sceneProperty =
-          this.addButtonSceneProperty(node, genScenesOutputEndpoint);
-        sceneProperty.buttonIndex = 4;
-      }
+        node.findZhaEndpointWithOutputClusterIdHex(CLUSTER_ID.GENSCENES_HEX) ||
+        '1';    // fake in endpoint 1 as version E1810 is missing the GENSCENES output cluster
+
+      const sceneProperty =
+        this.addButtonSceneProperty(node, genScenesOutputEndpoint);
+      sceneProperty.buttonIndex = 4;
 
       // This is the IKEA remote with a center button and 4 other
       // buttons around the edge. The center button sends a toggle


### PR DESCRIPTION
an inline comment on this change is too long. I left it that way as I am uncertain of the preferred way to comment this kind of work-around. Please feel free to edit the PR or suggest how I should change the comment.
As far as I can tell, the latest remote from IKEA is either abusing the spec or, more likely, has a bug where '0005' ( = GENSCENES ) is missing from the output clusters. As this is the first time I've looked into this area, I may well be missing something significant.