### PR TITLE
experimentally add batteryPercentageRemaining

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,7 @@
       "scanChannels": 8190,
       "allowFTDISerial": false,
       "allowAMASerial": false,
+      "showBattery": false,
       "debug": ""
     },
     "schema": {
@@ -40,6 +41,11 @@
         "allowAMASerial": {
             "type": "boolean",
             "default": false
+        },
+        "showBattery": {
+          "type": "boolean",
+          "title": "Show Battery Percentage",
+          "description": "experimental: Show the 'batteryPercentageRemaining' attribute as a property. Note that this attribute is reported from a power constrained device with possibly low quality consumer-grade batteries. Therefore, it may not represent what you expect. Particularly, it may drop in large increments and may suddenly go from, say, 50% to 1%. This attribute is reported very infrequently, maybe as little as once a day, so may take a while to appear after being enabled."
         },
         "debug": {
           "type": "string",

--- a/zb-classifier.js
+++ b/zb-classifier.js
@@ -1033,8 +1033,7 @@ class ZigbeeClassifier {
 
   addPowerCfgVoltageProperty(node, genPowerCfgEndpoint) {
     let attr = 'batteryVoltage';
-    if (node.activeEndpoints[genPowerCfgEndpoint].deviceId ==
-        ZHA_DEVICE_ID.SMART_PLUG) {
+    if (node.isMainsPowered()) {
       attr = 'mainsVoltage';
     }
     this.addProperty(
@@ -1056,8 +1055,7 @@ class ZigbeeClassifier {
       'parseNumericTenthsAttr',       // parseValueFromAttr
       CONFIG_REPORT_BATTERY
     );
-    if (node.activeEndpoints[genPowerCfgEndpoint].deviceId !=
-        ZHA_DEVICE_ID.SMART_PLUG) {
+    if (node.isBatteryPowered()) {
       const attrBP = 'batteryPercentageRemaining';
       this.addProperty(
         node,                     // device

--- a/zb-classifier.js
+++ b/zb-classifier.js
@@ -1058,10 +1058,10 @@ class ZigbeeClassifier {
     );
     if (node.activeEndpoints[genPowerCfgEndpoint].deviceId !=
         ZHA_DEVICE_ID.SMART_PLUG) {
-      const attr_bp = 'batteryPercentageRemaining';
+      const attrBP = 'batteryPercentageRemaining';
       this.addProperty(
         node,                     // device
-        attr_bp,                  // name
+        attrBP,                   // name
         {// property description
           label: 'Battery Percentage Remaining',
           type: 'number',
@@ -1075,7 +1075,7 @@ class ZigbeeClassifier {
         PROFILE_ID.ZHA,           // profileId
         genPowerCfgEndpoint,      // endpoint
         CLUSTER_ID.GENPOWERCFG,   // clusterId
-        attr_bp,                  // attr
+        attrBP,                   // attr
         '',                       // setAttrFromValue
         'parseHalfPercentAttr',   // parseValueFromAttr
         null,                     // configReport - use device internal settings

--- a/zb-classifier.js
+++ b/zb-classifier.js
@@ -1056,6 +1056,32 @@ class ZigbeeClassifier {
       'parseNumericTenthsAttr',       // parseValueFromAttr
       CONFIG_REPORT_BATTERY
     );
+    if (node.activeEndpoints[genPowerCfgEndpoint].deviceId !=
+        ZHA_DEVICE_ID.SMART_PLUG) {
+      const attr_bp = 'batteryPercentageRemaining';
+      this.addProperty(
+        node,                     // device
+        attr_bp,                  // name
+        {// property description
+          label: 'Battery Percentage Remaining',
+          type: 'number',
+          unit: 'percent',
+          minimum: 0,
+          maximum: 100,
+          multipleOf: 0.5,
+          readOnly: true,
+          visible: !!node.driver.config.showBattery,
+        },
+        PROFILE_ID.ZHA,           // profileId
+        genPowerCfgEndpoint,      // endpoint
+        CLUSTER_ID.GENPOWERCFG,   // clusterId
+        attr_bp,                  // attr
+        '',                       // setAttrFromValue
+        'parseHalfPercentAttr',   // parseValueFromAttr
+        null,                     // configReport - use device internal settings
+        null                      // defaultValue
+      );
+    }
   }
 
   addTemperatureSensorProperty(node, msTemperatureEndpoint) {

--- a/zb-node.js
+++ b/zb-node.js
@@ -408,6 +408,10 @@ class ZigbeeNode extends Device {
            this.powerSource != POWERSOURCE.BATTERY;
   }
 
+  isBatteryPowered() {
+    return this.powerSource == POWERSOURCE.BATTERY;
+  }
+
   endpointHasZhaInputClusterIdHex(endpoint, clusterIdHex) {
     if (endpoint.profileId == PROFILE_ID.ZHA_HEX ||
         endpoint.profileId == PROFILE_ID.ZLL_HEX) {

--- a/zb-property.js
+++ b/zb-property.js
@@ -516,6 +516,26 @@ class ZigbeeProperty extends Property {
     return [illuminance, `${illuminance.toFixed(0)} (${measuredValue})`];
   }
 
+  /**
+   * @method parseHalfPercentAttr
+   *
+   * Parses a percentage attribute into a property.
+   */
+  parseHalfPercentAttr(attrEntry) {
+    let percentage = null;
+    if (typeof attrEntry.attrData !== 'number') {
+      console.error('zb-property.js/parseHalfPercentAttr:',
+                    'expected attrEntry.attrData to be a number, found a ',
+                    typeof attrEntry.attrData);
+    } else if (attrEntry.attrData === 0xFF) {
+      console.error('zb-property.js/parseHalfPercentAttr:',
+                    'device reported "invalid value", 0xFF');
+    } else {
+      percentage = attrEntry.attrData / 2;
+    }
+    return [percentage, `${percentage} (${attrEntry.attrData})`];
+  }
+
   attrToTemperature(measuredValue) {
     return measuredValue / 100;
   }


### PR DESCRIPTION
This property attribute/property is hidden behind a configuration flag

On battery powered devices, suppresses the occasional log message
2020-11-21 00:58:46.994 INFO   : zigbee-adapter: handleReadRsp: ##### No property found for frame ##### zb-286d97000101d27f-door-sensor remote64: 286d97000101d27f profileId: 0104 clusterId: 0001 sourceEndpoint: 01 cmdId: report payload: [{"attrId":33,"dataType":32,"attrData":200}]