### PR TITLE
Added ColorTemperature property for ZHA devices

### DIFF
--- a/zb-classifier.js
+++ b/zb-classifier.js
@@ -338,7 +338,7 @@ class ZigbeeClassifier {
       '',                             // setAttrFromValue
       'parseNumericAttr',             // parseValueFromAttr
       null,                           // configReport
-      153                             // defaultValue (153 = 6500K)
+      153                             // defaultValue (153 = 6535K)
     );
     this.addProperty(
       node,                           // device
@@ -2132,6 +2132,9 @@ class ZigbeeClassifier {
             colorCapabilities |= COLOR_CAPABILITY.HUE_SAT;
           }
         }
+        if (ZHA_DEVICE_ID.isColorTemperatureLight(levelEndpoint.deviceId)) {
+          isColorTemperatureLight = true;
+        }
       }
     }
 
@@ -2157,14 +2160,15 @@ class ZigbeeClassifier {
         node['@type'] = ['Light', 'ColorControl', 'OnOffSwitch'];
       } else {
         if (isColorTemperatureLight) {
-          // Color temperature is basically a specialized way of selecting
-          // a color, so we don't include this property with full-color
-          // bulbs.
           this.addColorTemperatureProperty(node,
                                            node.lightingColorCtrlEndpoint);
+          this.addBrightnessProperty(node, genLevelCtrlEndpoint);
+          node['@type'] = ['Light', 'ColorControl', 'OnOffSwitch'];
         }
-        this.addBrightnessProperty(node, genLevelCtrlEndpoint);
-        node['@type'] = ['Light', 'OnOffSwitch'];
+        else {
+          this.addBrightnessProperty(node, genLevelCtrlEndpoint);
+          node['@type'] = ['Light', 'OnOffSwitch'];
+        }
       }
     } else {
       this.addLevelProperty(node, genLevelCtrlEndpoint);

--- a/zb-classifier.js
+++ b/zb-classifier.js
@@ -2158,17 +2158,14 @@ class ZigbeeClassifier {
           this.addColorXYProperty(node, node.lightingColorCtrlEndpoint);
         }
         node['@type'] = ['Light', 'ColorControl', 'OnOffSwitch'];
+      } else if (isColorTemperatureLight) {
+        this.addColorTemperatureProperty(node,
+                                         node.lightingColorCtrlEndpoint);
+        this.addBrightnessProperty(node, genLevelCtrlEndpoint);
+        node['@type'] = ['Light', 'ColorControl', 'OnOffSwitch'];
       } else {
-        if (isColorTemperatureLight) {
-          this.addColorTemperatureProperty(node,
-                                           node.lightingColorCtrlEndpoint);
-          this.addBrightnessProperty(node, genLevelCtrlEndpoint);
-          node['@type'] = ['Light', 'ColorControl', 'OnOffSwitch'];
-        }
-        else {
-          this.addBrightnessProperty(node, genLevelCtrlEndpoint);
-          node['@type'] = ['Light', 'OnOffSwitch'];
-        }
+        this.addBrightnessProperty(node, genLevelCtrlEndpoint);
+        node['@type'] = ['Light', 'OnOffSwitch'];
       }
     } else {
       this.addLevelProperty(node, genLevelCtrlEndpoint);

--- a/zb-constants.js
+++ b/zb-constants.js
@@ -362,6 +362,9 @@ const ZHA_DEVICE_ID = {
     return deviceId == ZHA_DEVICE_ID.COLORED_DIMMABLE_LIGHT ||
            deviceId == ZHA_DEVICE_ID.EXTENDED_COLOR_LIGHT;
   },
+  isColorTemperatureLight: function isColorTemperatureLight(deviceId) {
+    return deviceId == ZHA_DEVICE_ID.COLOR_TEMPERATURE_LIGHT;
+  },
 };
 
 // ZLL Device Id describes device IDs from the ZLL spec.


### PR DESCRIPTION
This is a solution for Issue #282, LIDL Livarno Lux Lights - Color Temperature not working.

Fixes #282

