### PR TITLE
Stop all properties being removed by default

### DIFF
--- a/src/zb-classifier.js
+++ b/src/zb-classifier.js
@@ -1933,6 +1933,9 @@ ${(`0${d.getHours()}`).slice(-2)}:${(`0${d.getMinutes()}`).slice(-2)}:${(`0${d.g
 
     if (name[0] == '_') {
       property.visible = false;
+      // Invisible properties are no longer exposed in Thing Descriptions so
+      // should eventually be removed entirely.
+      // See https://github.com/WebThingsIO/zigbee-adapter/issues/334
     }
     property.setInitialReadNeeded();
     property.defaultValue = defaultValue;

--- a/src/zb-node.js
+++ b/src/zb-node.js
@@ -236,8 +236,10 @@ class ZigbeeNode extends Device {
       }
     }
 
+    // Remove invisible properties from the Thing Description
+    // See https://github.com/WebThingsIO/zigbee-adapter/issues/334
     for (const prop of Object.values(dict.properties)) {
-      if (!prop.visible) {
+      if (prop.hasOwnProperty('visible') && prop.visible === false) {
         delete dict.properties[prop.name];
       }
     }

--- a/src/zb-property.js
+++ b/src/zb-property.js
@@ -871,7 +871,11 @@ class ZigbeeProperty extends Property {
       // and there is nothing that we can actually read.
       return;
     }
-    if (!this.visible && typeof this.value != 'undefined') {
+    if (
+      this.hasOwnProperty('visible') &&
+      this.visible === false &&
+      typeof this.value != 'undefined'
+    ) {
       // We already know the value for this invisible property,
       // no need to read it again.
       return;


### PR DESCRIPTION
Fixes https://github.com/WebThingsIO/gateway/issues/3126 for the Zigbee adapter.

In previous versions of the gateway all properties had a `visible` member which was set to true by default. The Zigbee adapter currently assumes that all properties have a `visible` member and removes from Thing Descriptions if it doesn't evaluate to `true`. The latest version of the gateway never adds a `visible` member to property descriptions.

This tweak makes sure that properties are not removed by default, and instead only removed if a `visible` member is explicitly set to `false`.

Invisible properties should eventually be re-factored out altogether, see #334.