### PR TITLE
Fix hiding invisible properties - closes #337

### DIFF
--- a/src/zb-property.js
+++ b/src/zb-property.js
@@ -125,6 +125,9 @@ class ZigbeeProperty extends Property {
     dict.bindNeeded = this.bindNeeded;
     dict.configReportNeeded = this.configReportNeeded;
     dict.initialReadNeeded = this.initialReadNeeded;
+    if (this.hasOwnProperty('visible')) {
+      dict.visible = this.visible;
+    }
     if (this.hasOwnProperty('level')) {
       dict.level = this.level;
     }


### PR DESCRIPTION
It turns out that the hiding of invisible properties wasn't working because the `visible` member of property affordances was not being preserved by `ZigbeeProperty.asDict()`.

This PR makes sure that if the visible member exists on the ZigbeeProperty instance, it is included in the dictionary, so that `ZigbeeNode` eventually removes that property. I hope to eventually get rid of this altogether in #334