### PR TITLE
Delete npm cache before packaging - closes #355

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -120,5 +120,5 @@
     }
   },
   "short_name": "Zigbee",
-  "version": "2.0.0"
+  "version": "2.0.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zigbee-adapter",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zigbee-adapter",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MPL-2.0",
       "dependencies": {
         "bl": "^4.1.0",
@@ -496,9 +496,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
-      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zigbee-adapter",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Zigbee device support, via USB dongle or external Zigbee2MQTT instance.",
   "author": "WebThingsIO",
   "main": "lib/index.js",

--- a/package.sh
+++ b/package.sh
@@ -18,6 +18,9 @@ npm ci
 npm run build
 npm prune --production
 
+# Remove internal package-lock cache which can cause checksum errors at runtime
+rm -f node_modules/.package-lock.json
+
 shasum --algorithm 256 manifest.json package.json lib/*.js lib/driver/*.js lib/zigbee2mqtt/*.js LICENSE README.md > SHA256SUMS
 
 find node_modules \( -type f -o -type l \) -exec shasum --algorithm 256 {} \; >> SHA256SUMS


### PR DESCRIPTION
I don't know why this .package-lock.json file is placed in node_modules/ or why it gets modified after packaging and installation on the gateway but this is causing the checksum of the add-on to fail at startup.

From what I have read this is an internal cache created by npm which can safely be deleted, so I have modified the packaging script to delete it before distribution. This seems to fix the checksum errors seen in #355.

Closes #355.