### PR TITLE
Apply OccupancySensor and OccupiedProperty types to occupancy sensors - closes #351

### DIFF
--- a/src/zb-classifier.js
+++ b/src/zb-classifier.js
@@ -1036,7 +1036,7 @@ class ZigbeeClassifier {
       'occupied', // name
       {
         // property description
-        '@type': 'BooleanProperty',
+        '@type': 'OccupiedProperty',
         type: 'boolean',
         label: 'Occupied',
         description: 'Occupancy Sensor',
@@ -1066,6 +1066,9 @@ class ZigbeeClassifier {
       '', // setAttrFromValue
       'parseOccupancySensorTypeAttr' // parseValueFromAttr
     );
+    if (!node['@type'].includes('OccupancySensor')) {
+      node['@type'].push('OccupancySensor');
+    }
   }
 
   addIlluminanceMeasurementProperty(node, msMeasurementEndpoint) {
@@ -2120,6 +2123,9 @@ ${(`0${d.getHours()}`).slice(-2)}:${(`0${d.getMinutes()}`).slice(-2)}:${(`0${d.g
     if (genPowerCfgEndpoint) {
       this.addPowerCfgVoltageProperty(node, genPowerCfgEndpoint);
     }
+    if (msOccupancySensingEndpoint) {
+      this.addOccupancySensorProperty(node, msOccupancySensingEndpoint);
+    }
 
     this.addLastSeenProperty(node);
   }
@@ -2215,7 +2221,7 @@ ${(`0${d.getHours()}`).slice(-2)}:${(`0${d.getMinutes()}`).slice(-2)}:${(`0${d.g
   }
 
   initOccupancySensor(node, msOccupancySensingEndpoint) {
-    node['@type'] = ['BinarySensor'];
+    node['@type'] = ['OccupancySensor'];
     node.type = 'sensor';
     node.name = `${node.id}-occupancy`;
 


### PR DESCRIPTION
This PR means that Zigbee occupancy sensors will be classified using the new [`OccupancySensor`](https://webthings.io/schemas/#OccupancySensor) schema with an [`OccupiedProperty`](https://webthings.io/schemas/#OccupiedProperty) as opposed to a generic `BinarySensor` with a `BooleanProperty`.

It also allows an `OccupancyProperty` to be added to other device types like a `MotionSensor` if present.